### PR TITLE
Add autowiring

### DIFF
--- a/DependencyInjection/MariaExtension.php
+++ b/DependencyInjection/MariaExtension.php
@@ -71,6 +71,8 @@ class MariaExtension extends Extension
 
         $definition = new Definition($ref);
         $definition->setPublic(true); //For tests.
+        $definition->setAutowired(true);
+        $definition->setAutoconfigured(true);
 
 
         if (!method_exists($definition->getClass(), $handler['method'])) {

--- a/MariaEventArg.php
+++ b/MariaEventArg.php
@@ -4,7 +4,7 @@
 namespace SweetCode\MariaBundle;
 
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class MariaEventArg extends Event
 {

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ $context = [
     'amount'        => $order->getAmount(),
     'category_id'   => $order->getCategoryId(),
 ]
-$eventDispatcher->dispatch('cart.updated', new \SweetCode\MariaBundle\MariaEventArg($context));
+$eventDispatcher->dispatch(new \SweetCode\MariaBundle\MariaEventArg($context), 'cart.updated');
 //...
 ```
 

--- a/Tests/Integration/SimpleIntegrationTest.php
+++ b/Tests/Integration/SimpleIntegrationTest.php
@@ -67,7 +67,7 @@ class SimpleIntegrationTest extends TestCase
         /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $container->get('event_dispatcher');
 
-        $dispatcher->dispatch('some.event', $mariaEventArg);
+        $dispatcher->dispatch($mariaEventArg, 'some.event');
     }
 
     public function testUnmatchedScenario()
@@ -82,7 +82,7 @@ class SimpleIntegrationTest extends TestCase
         /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $container->get('event_dispatcher');
 
-        $dispatcher->dispatch('some.event', $mariaEventArg);
+        $dispatcher->dispatch($mariaEventArg, 'some.event');
     }
 
     public function testConflictedScenarios()
@@ -99,7 +99,7 @@ class SimpleIntegrationTest extends TestCase
         /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = $container->get('event_dispatcher');
 
-        $dispatcher->dispatch('some.event', $mariaEventArg);
+        $dispatcher->dispatch($mariaEventArg, 'some.event');
     }
 
     /**

--- a/Tests/Integration/SimpleIntegrationTest.php
+++ b/Tests/Integration/SimpleIntegrationTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SimpleIntegrationTest extends TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
   },
   "require": {
     "php": "^5.6.2|^7.0",
-    "symfony/dependency-injection": "^3.4|^4.0",
-    "symfony/framework-bundle":     "^3.4|^4.0",
-    "symfony/config":               "^3.4|^4.0",
-    "symfony/yaml":                 "^3.4|^4.0",
-    "symfony/event-dispatcher":     "^3.4|^4.0",
-    "symfony/serializer":           "^3.4|^4.0",
-    "symfony/property-access":      "^3.4|^4.0"
+    "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+    "symfony/framework-bundle":     "^3.4|^4.0|^5.0",
+    "symfony/config":               "^3.4|^4.0|^5.0",
+    "symfony/yaml":                 "^3.4|^4.0|^5.0",
+    "symfony/event-dispatcher":     "^3.4|^4.0|^5.0",
+    "symfony/serializer":           "^3.4|^4.0|^5.0",
+    "symfony/property-access":      "^3.4|^4.0|^5.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
   },
   "require": {
     "php": "^5.6.2|^7.0",
-    "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-    "symfony/framework-bundle":     "^3.4|^4.0|^5.0",
-    "symfony/config":               "^3.4|^4.0|^5.0",
-    "symfony/yaml":                 "^3.4|^4.0|^5.0",
-    "symfony/event-dispatcher":     "^3.4|^4.0|^5.0",
-    "symfony/serializer":           "^3.4|^4.0|^5.0",
-    "symfony/property-access":      "^3.4|^4.0|^5.0"
+    "symfony/dependency-injection": "^4.4|^5.0",
+    "symfony/framework-bundle":     "^4.4|^5.0",
+    "symfony/config":               "^4.4|^5.0",
+    "symfony/yaml":                 "^4.4|^5.0",
+    "symfony/event-dispatcher":     "^4.4|^5.0",
+    "symfony/serializer":           "^4.4|^5.0",
+    "symfony/property-access":      "^4.4|^5.0"
   }
 }


### PR DESCRIPTION
As I said in #9, the best solution for this would be to tag the services and add them to the handler in the compiler pass. In the meantime, this PR will allow the handlers to define their dependencies in the constructor.